### PR TITLE
58Users List Layout - Some times Role ID is displayed instead of Role…

### DIFF
--- a/ngDesk-UI/src/app/render-layout/render-list-layout-new/render-list-layout-new.component.ts
+++ b/ngDesk-UI/src/app/render-layout/render-list-layout-new/render-list-layout-new.component.ts
@@ -639,14 +639,12 @@ export class RenderListLayoutNewComponent implements OnInit, OnDestroy {
 		this.formatChronometerFields(entriesReponse);
 		const entry = entriesReponse;
 		for (let i = 0; i < entriesReponse.DATA.length; i++) {
-			if (entriesReponse.DATA[i].ROLE !== undefined) {
-				const roleId = entriesReponse.DATA[i].ROLE;
-				const role = this.allRoles.find((allRole) => {
-					return allRole.ROLE_ID === roleId;
-				});
-				if (role !== undefined) {
-					entriesReponse.DATA[i].ROLE = role.NAME;
-				}
+			const roleId = entriesReponse.DATA[i].ROLE;
+			const role = this.allRoles.find((allRole) => {
+				return allRole.ROLE_ID === roleId;
+			});
+			if (role !== undefined) {
+				entriesReponse.DATA[i].ROLE = role.NAME;
 			}
 		}
 


### PR DESCRIPTION
Closes #58 

##### Test Case 1

Name:Role Id is displayed instead of role name

1. Login to ngdesk.
2. Go to -> company settings ->users -> click refresh button on the page.
3. Observe Role Names.

##### Test Case 2
Name:save and return' button in Edit Users layout

1. Login to ngdesk.
2. Go to ->company settings -> users -> save and return' button in Edit Users layout.
3. Observe Role Names


#### Screenshots:-

![Screenshot from 2021-08-31 17-11-19](https://user-images.githubusercontent.com/89505134/131496335-0e5cb1cf-9637-4d33-88d0-b5add8d2c0d1.png)
