### PR TITLE
PDF template is not display drop down when data is present in creating signature document workflow node.

### DIFF
--- a/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/triggers-detail.service.ts
+++ b/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/triggers-detail.service.ts
@@ -222,7 +222,7 @@ export class TriggersDetailService {
 			);
 
 		const templatesResponse = this.htmlTemplateApiService
-			.getTemplates(this.moduleId)
+			.getTemplates(moduleId)
 			.pipe(
 				map((response) => {
 					return response['content'];


### PR DESCRIPTION
#### Reference to issue (Required)

Closes #149 

#### Checklist (Required)

- [x] code is clean, clear, and concise
- [x] coding conventions have been followed
- [x] the issue is updated with time spent

#### Description (Required)

* PDF template is not displayed while creating signature document workflow node.

#### Manual Test Preformed (Required)
List the manual tests that were performed and the steps to perform them  
**There must be multiple test cases provided, each test case should include the exact and detailed steps to replicate the case**


##### Test Case 1
**Name: DisplayField**
**Exact Detailed Steps:**
1. Go to modules > Tickets
2.go to PDF templates > click new > create one
3. save it
4. go to workflows > click new
5. select signature workflow node
6. PDF template drop ll show up
7. try few times , with and without pdf  templates
8. No console errror

![Screenshot from 2021-09-03 13-18-52](https://user-images.githubusercontent.com/89504219/131980990-e9178ee5-78cf-4f4f-b650-16a552f3e0c6.png)
![Screenshot from 2021-09-03 13-19-04](https://user-images.githubusercontent.com/89504219/131980997-41ca1b73-6a04-4d8e-a7a3-4fbbba0f431f.png)

#### Types of changes (Required)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)