### PR TITLE
138 populate channels on search

### DIFF
--- a/ngDesk-UI/src/app/custom-components/search-bar/search-bar.component.ts
+++ b/ngDesk-UI/src/app/custom-components/search-bar/search-bar.component.ts
@@ -18,6 +18,7 @@ import { ActivatedRoute } from '@angular/router';
 import { DataApiService } from '@ngdesk/data-api';
 import { TranslateService } from '@ngx-translate/core';
 import { CacheService } from '@src/app/cache.service';
+import { ChannelsService } from '@src/app/channels/channels.service';
 import { RenderListLayoutService } from '@src/app/render-layout/render-list-layout-new/render-list-layout.service';
 import { Subscription } from 'rxjs';
 import { ModulesService } from '../../modules/modules.service';
@@ -69,7 +70,8 @@ export class SearchBarComponent implements OnChanges {
 		private translateService: TranslateService,
 		private cacheService: CacheService,
 		private dataService: DataApiService,
-		private renderListLayoutService: RenderListLayoutService
+		private renderListLayoutService: RenderListLayoutService,
+		private channelsService: ChannelsService
 	) {}
 	// constructor(private modulesService: ModulesService, private route: ActivatedRoute,
 	// private autocompleteService: AutocompleteService) { }
@@ -633,6 +635,14 @@ export class SearchBarComponent implements OnChanges {
 						false,
 						this.searchString
 					);
+				} else if (selectedField['DATA_TYPE']['DISPLAY'] === 'Text') {
+					debugger;
+					this.channelsService
+						.getAllChannels(this.moduleId)
+						.subscribe((response: any) => {
+							this.fieldEntries = response.CHANNELS;
+							this.detectSearchValueChanges('entries');
+						});
 				} else {
 					this.fieldEntries = [];
 				}

--- a/ngDesk-UI/src/app/custom-components/search-bar/search-bar.component.ts
+++ b/ngDesk-UI/src/app/custom-components/search-bar/search-bar.component.ts
@@ -408,6 +408,12 @@ export class SearchBarComponent implements OnChanges {
 								DATA_ID: entry['DATA_ID'],
 							});
 						}
+					} else if (previousField.DATA_TYPE.DISPLAY === 'Text') {
+						this.fieldOptions.push({
+							VALUE: entry['NAME'],
+							TYPE: 'entry',
+							NAME: previousField['NAME'],
+						});
 					} else {
 						this.fieldOptions.push({
 							VALUE: entry,
@@ -635,8 +641,10 @@ export class SearchBarComponent implements OnChanges {
 						false,
 						this.searchString
 					);
-				} else if (selectedField['DATA_TYPE']['DISPLAY'] === 'Text') {
-					debugger;
+				} else if (
+					selectedField['DATA_TYPE']['DISPLAY'] === 'Text' &&
+					selectedField['NAME'] === 'CHANNEL'
+				) {
 					this.channelsService
 						.getAllChannels(this.moduleId)
 						.subscribe((response: any) => {


### PR DESCRIPTION
#### Reference to issue #138 

Closes #138 

#### Description (Required)

Channel values are populated in render list layout

##### Test Case 1

**Name:For Tickets Module**

1. Click on Tickets in side bar
2.  Search Channel and observe the populating values


##### Test Case 2

**Name:For Contacts Module**

1. Click on Contacts in side bar
2.  Search Channel and observe the populating values

#### List of General Components affected (Required)
SearchBarComponent

**screen-shots**

![channel1](https://user-images.githubusercontent.com/89504408/131872151-d4cbfea9-c94e-46f8-bfcd-726232e61b93.png)
![channel2](https://user-images.githubusercontent.com/89504408/131872184-bc95f9b5-097b-48b9-a4d0-d2e7bb3a9136.png)
![channel3](https://user-images.githubusercontent.com/89504408/131872242-8cc9b660-76b2-4676-a1a1-ce891dd7dfc4.png)
![channel4](https://user-images.githubusercontent.com/89504408/131872274-01a25862-c1bd-4adf-a2ad-a3805431cfe0.png)
![channel5](https://user-images.githubusercontent.com/89504408/131872300-27112435-4ca4-4c3a-8411-c94d0d7f87e3.png)
![channel6](https://user-images.githubusercontent.com/89504408/131872335-21366c85-1d9d-4012-a4c6-fdd6bbb261f0.png)

