### PR TITLE
fixed search of schedules in escalations

### DIFF
--- a/ngDesk-UI/src/app/custom-components/conditions/filter-rule-option/filter-rule-option.pipe.ts
+++ b/ngDesk-UI/src/app/custom-components/conditions/filter-rule-option/filter-rule-option.pipe.ts
@@ -25,9 +25,7 @@ export class FilterRuleOptionPipe implements PipeTransform {
 					) {
 						filteredItems.push(item);
 					} else {
-						if (
-							item.FULL_NAME.toLowerCase().includes(input)
-						) {
+						if (item.FULL_NAME.toLowerCase().includes(input)) {
 							filteredItems.push(item);
 						}
 					}
@@ -46,7 +44,7 @@ export class FilterRuleOptionPipe implements PipeTransform {
 
 			case 'schedules': {
 				items.forEach((item) => {
-					if (item.NAME.toLowerCase().includes(input)) {
+					if (item.name.toLowerCase().includes(input)) {
 						filteredItems.push(item);
 					}
 				});


### PR DESCRIPTION
#### Reference to issue #162 

Closes #162 

#### Description (Required)

search should works for schedules in escalations

##### Test Case 1

**Name:For create escalations**

1.Click on escalations under pager in side bar
2.Click on new
3.try to search schedules


##### Test Case 2

**Name:For edit escalations**

1.Click on escalations under pager in side bar
2.Click on saved entry 
3.try to search schedules


#### List of General Components affected (Required)

filterRuleOption pipe

**screen-shots**

![esc1](https://user-images.githubusercontent.com/89504408/132433568-41cd3921-1e46-4f14-8281-a40a7ab5dca3.png)
![esc2](https://user-images.githubusercontent.com/89504408/132433573-07ed2c54-156b-4102-a9d0-63d1c8fe54a2.png)
![esc3](https://user-images.githubusercontent.com/89504408/132433580-edc223fe-93a6-4e81-a51d-28d7693f1055.png)
![esc4](https://user-images.githubusercontent.com/89504408/132433594-af39c141-2336-4529-b719-2fd4148fb6c8.png)
![esc5](https://user-images.githubusercontent.com/89504408/132433595-5f59098d-2395-43ee-a3b4-76633ed3bed9.png)
![esc6](https://user-images.githubusercontent.com/89504408/132433603-0d2133f9-e908-41a5-920a-cfe0cac80b69.png)

