### PR TITLE
Fixed schedule search in escalation page

### DIFF
--- a/ngDesk-UI/src/app/custom-components/conditions/filter-rule-option/filter-rule-option.pipe.ts
+++ b/ngDesk-UI/src/app/custom-components/conditions/filter-rule-option/filter-rule-option.pipe.ts
@@ -25,9 +25,7 @@ export class FilterRuleOptionPipe implements PipeTransform {
 					) {
 						filteredItems.push(item);
 					} else {
-						if (
-							item.FULL_NAME.toLowerCase().includes(input)
-						) {
+						if (item.FULL_NAME.toLowerCase().includes(input)) {
 							filteredItems.push(item);
 						}
 					}
@@ -46,7 +44,7 @@ export class FilterRuleOptionPipe implements PipeTransform {
 
 			case 'schedules': {
 				items.forEach((item) => {
-					if (item.NAME.toLowerCase().includes(input)) {
+					if (item.name.toLowerCase().includes(input)) {
 						filteredItems.push(item);
 					}
 				});


### PR DESCRIPTION
Closes #36 

Test Case 1
**Name: Escalation searchable schedule list**
1. Login to ngdesk.
2. Goto -> Pager -> escalation -> new.
3. Make sure you have created 10-15 schedules.
4. Fill details in escalation page.
5. Click on schedule field.
6. Observe the drop down.
7. Type something.
8. Observe getting filtered based on typed letter.
9. Observe no error.

Test Case 2
**Name: Create Escalation**
1. Login to ngdesk.
2. Goto -> Pager -> escalation -> new.
3. Make sure you have created 10-15 schedules.
4. Fill details in escalation page.
5. Click on schedule field.
6. Observe the drop down.
7. Type something.
8. Observe getting filtered based on typed letter.
9. Select the schedule.
10. Hit save.
11. Observed getting saved.
12. Observe no error.

Test Case 3
**Name: Edit Escalation**
1. Login to ngdesk.
2. Goto -> Pager -> escalation -> click on schedule created above.
3. Click on schedule field.
4. Observe the drop down.
5. Type something.
6. Observe getting filtered based on typed letter.
7. Select the schedule.
8. Hit save.
9. Observed getting updated.
10. Observe no error.

Screenshots :-   

![Screenshot from 2021-09-10 16-23-00](https://user-images.githubusercontent.com/89504119/132842979-0f707b84-b9df-459a-ba90-59b17bb9a1f3.png)

![Screenshot from 2021-09-10 16-23-09](https://user-images.githubusercontent.com/89504119/132842991-acdd1cb3-7dea-48f6-ab73-52dca2006ff2.png)
