### PR TITLE
signature document node edit not working on prod

### DIFF
--- a/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/node-customization/node-customization.component.ts
+++ b/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/node-customization/node-customization.component.ts
@@ -337,7 +337,7 @@ export class NodeCustomizationComponent implements OnInit {
 			this.escalation = this.data.CELL_DATA.VALUE.ESCALATION;
 			this.htmlTemplate = this.data.CELL_DATA.VALUE.PDF_TEMPLATE;
 			this.signTemplate = this.data.CELL_DATA.VALUE.PDF_TEMPLATE_ID;
-			this.storeTemplate = this.data.CELL_DATA.FIELD_ID;
+			this.storeTemplate = this.data.CELL_DATA.VALUE.FIELD_ID;
 			this.updateFields = this.data.CELL_DATA.VALUE.FIELDS;
 			this.channelId = this.data.CELL_DATA.VALUE.CHANNEL_ID;
 			this.createEntryModuleId = this.data.CELL_DATA.VALUE.MODULE;
@@ -399,7 +399,7 @@ export class NodeCustomizationComponent implements OnInit {
 		this.dialogRef.close();
 	}
 
-	createnewPdf(){
+	createnewPdf() {
 		this.router.navigate([`modules/${this.moduleId}/pdf/new`]);
 		this.dialogRef.close();
 	}

--- a/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/triggers-detail.service.ts
+++ b/ngDesk-UI/src/app/modules/modules-detail/triggers/triggers-detail-new/triggers-detail.service.ts
@@ -222,7 +222,7 @@ export class TriggersDetailService {
 			);
 
 		const templatesResponse = this.htmlTemplateApiService
-			.getTemplates(this.moduleId)
+			.getTemplates(moduleId)
 			.pipe(
 				map((response) => {
 					return response['content'];
@@ -572,7 +572,7 @@ export class TriggersDetailService {
 				cell.VALUE.FROM = node['FROM'];
 				cell.VALUE.SUBJECT = node['SUBJECT'];
 				cell.VALUE.PDF_TEMPLATE_ID = node['PDF_TEMPLATE_ID'];
-				cell.value.FIELD_ID = node['FIELD_ID'];
+				cell.VALUE.FIELD_ID = node['FIELD_ID'];
 			}
 			cellData.push(cell);
 		});


### PR DESCRIPTION
#### Reference to issue #180 

Closes #180 

#### Description (Required)

fixed signature Document node edit is not working

##### Test Case 1

1. Click on modules in side bar
2. click on tickets
3. create one file upload data type field and create one pdf
4. Click on workflows ->click on new->enter required data fields
5. Drag the sign Document node and click on sign Document node->enter the all values for fields
6. click on save and click on main save of workflow
7. open the saved workflow and click on sign document node and observe the values

##### Test Case 2

1. Click on modules in side bar
2. click on products
3. create one file upload data type field and create one pdf
4. Click on workflows ->click on new->enter required data fields
5. Drag the sign Document node and click on sign Document node->enter the all values for fields
6. click on save and click on main save of workflow
7. open the saved workflow and click on sign document node and observe the values


#### List of General Components affected (Required)

NodeCustomizationComponent,TriggersDetailService


**screen-shots**

![signDocumentTickets](https://user-images.githubusercontent.com/89504408/133021109-991166e5-eee3-4149-8ab3-ec02816333b3.png)
![signDocumentTickets1](https://user-images.githubusercontent.com/89504408/133202828-5961464e-89fe-4bd1-955a-423a7fb9b011.png)
![signDocumentProducts](https://user-images.githubusercontent.com/89504408/133021115-f345b0e5-ad9e-4d73-a070-9d0d77f96475.png)


