### PR TITLE
theme changed for reset password page

### DIFF
--- a/ngDesk-UI/src/app/reset-password/reset-password.component.html
+++ b/ngDesk-UI/src/app/reset-password/reset-password.component.html
@@ -45,10 +45,6 @@
 			</mat-card>
 		</form>
 	</div>
-
-	<!-- <div fxLayout="row" fxLayoutAlign="end end" style="padding: 5px;color: white;">
-		<label style="color: white;" class="mat-body" [innerHTML]="'BACKLINK_TEXT' | translate"></label>
-	</div> -->
 	<div fxLayoutAlign="end end" style="padding: 20px">
 		<label style="color: white;" class=" mat-body"><a style="color: white;" href="https://www.ngdesk.com" target="_blank">Powered by
 				ngDesk</a> &#169;</label>

--- a/ngDesk-UI/src/app/reset-password/reset-password.component.html
+++ b/ngDesk-UI/src/app/reset-password/reset-password.component.html
@@ -1,52 +1,56 @@
 <!DOCTYPE html>
-<div fxLayout="column" fxLayoutAlign="center" style="min-height:95vh">
-  <div fxLayoutAlign="center">
-    <form fxFlex="40" [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()">
-      <mat-card fxLayout="column" fxLayoutGap="20px">
-        <div fxLayoutAlign="center" class="mat-h1" color="primary" style="margin-top:50px">{{ title | translate }}</div>
-        <div fxLayoutAlign="center" class="mat-h3" color="primary">{{'NEW_CONFIRM_PASSWORD' | translate}}</div>
-        <mat-error class="mat-small"> {{ errorMessage }}</mat-error>
-        <mat-form-field fxFlex appearance="outline">
-          <mat-label>{{'PASSWORD' | translate}}</mat-label>
-          <input matInput formControlName="password" [type]="hidePassword ? 'password' : 'text'">
-          <mat-icon matSuffix (click)="hidePassword = !hidePassword">{{hidePassword ? 'visibility_off' : 'visibility'}}
-          </mat-icon>
-          <mat-error *ngIf="resetPasswordForm.controls.password.hasError('required')">
-            {{'PLEASE_ENTER_YOUR_NEW_PASSWORD' | translate}}
-          </mat-error>
-          <mat-error *ngIf="resetPasswordForm.controls.password.hasError('minlength') &&
+<div fxLayout="column" style="height: 100vh;background: linear-gradient(var(--primaryColor),var(--blendColor))">
+	<div style="height:95vh" fxLayoutGap="20px" fxLayoutAlign="center center">
+		<form fxFlex="40" [formGroup]="resetPasswordForm" (ngSubmit)="resetPassword()">
+			<mat-card fxLayout="column" fxLayoutGap="20px">
+				<div fxLayoutAlign="center" class="mat-h1" color="primary" style="margin-top:50px">{{ title | translate }}</div>
+				<div fxLayoutAlign="center" class="mat-h3" color="primary">{{'NEW_CONFIRM_PASSWORD' | translate}}</div>
+				<mat-error class="mat-small"> {{ errorMessage }}</mat-error>
+				<mat-form-field fxFlex appearance="outline">
+					<mat-label>{{'PASSWORD' | translate}}</mat-label>
+					<input matInput formControlName="password" [type]="hidePassword ? 'password' : 'text'">
+					<mat-icon matSuffix (click)="hidePassword = !hidePassword">{{hidePassword ? 'visibility_off' : 'visibility'}}
+					</mat-icon>
+					<mat-error *ngIf="resetPasswordForm.controls.password.hasError('required')">
+						{{'PLEASE_ENTER_YOUR_NEW_PASSWORD' | translate}}
+					</mat-error>
+					<mat-error *ngIf="resetPasswordForm.controls.password.hasError('minlength') &&
             !resetPasswordForm.controls.password.hasError('required')">
-            {{'PASSWORD_SHOULD_MINIMUM_8_CHARACTERS' | translate}}
-          </mat-error>
-          <mat-error *ngIf="resetPasswordForm.controls.password.hasError('numberReq') &&
+						{{'PASSWORD_SHOULD_MINIMUM_8_CHARACTERS' | translate}}
+					</mat-error>
+					<mat-error *ngIf="resetPasswordForm.controls.password.hasError('numberReq') &&
             !resetPasswordForm.controls.password.hasError('required')">
-            {{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('NUMBER') } }}
-          </mat-error>
-          <mat-error *ngIf="resetPasswordForm.controls.password.hasError('uppercaseReq') &&
+						{{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('NUMBER') } }}
+					</mat-error>
+					<mat-error *ngIf="resetPasswordForm.controls.password.hasError('uppercaseReq') &&
             !resetPasswordForm.controls.password.hasError('required')">
-            {{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('CAPITAL_LETTER') } }}
-          </mat-error>
-          <mat-error *ngIf="resetPasswordForm.controls.password.hasError('specialCharReq') &&
+						{{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('CAPITAL_LETTER') } }}
+					</mat-error>
+					<mat-error *ngIf="resetPasswordForm.controls.password.hasError('specialCharReq') &&
             !resetPasswordForm.controls.password.hasError('required')">
-            {{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('SPECIAL_CHARACTER') }
+						{{'PASSWORD_MISSING_REQUIREMENT' | translate: { requirement: translateService.instant('SPECIAL_CHARACTER') }
             }}
-          </mat-error>
-        </mat-form-field>
-        <mat-form-field fxFlex appearance="outline">
-          <mat-label>{{'CONFIRM_PASSWORD' | translate}}</mat-label>
-          <input matInput formControlName="confirmPassword" [type]="hidePassword ? 'password' : 'text'"
-            [errorStateMatcher]="matcher">
-          <mat-error *ngIf="resetPasswordForm.hasError('notSame')">
-            {{'PASSWORD_DO_NOT_MATCH' | translate}}
-          </mat-error>
-        </mat-form-field>
-        <div fxLayout="column" fxLayoutAlign="center">
-          <button mat-raised-button color="primary" type="submit">{{'SUBMIT' | translate}}</button>
-        </div>
-      </mat-card>
-    </form>
-  </div>
-</div>
-<div fxLayout="row" fxLayoutAlign="end end" style="padding: 5px">
-  <label class="mat-body" [innerHTML]="'BACKLINK_TEXT' | translate"></label>
+					</mat-error>
+				</mat-form-field>
+				<mat-form-field fxFlex appearance="outline">
+					<mat-label>{{'CONFIRM_PASSWORD' | translate}}</mat-label>
+					<input matInput formControlName="confirmPassword" [type]="hidePassword ? 'password' : 'text'" [errorStateMatcher]="matcher">
+					<mat-error *ngIf="resetPasswordForm.hasError('notSame')">
+						{{'PASSWORD_DO_NOT_MATCH' | translate}}
+					</mat-error>
+				</mat-form-field>
+				<div fxLayout="column" fxLayoutAlign="center">
+					<button mat-raised-button color="primary" type="submit">{{'SUBMIT' | translate}}</button>
+				</div>
+			</mat-card>
+		</form>
+	</div>
+
+	<!-- <div fxLayout="row" fxLayoutAlign="end end" style="padding: 5px;color: white;">
+		<label style="color: white;" class="mat-body" [innerHTML]="'BACKLINK_TEXT' | translate"></label>
+	</div> -->
+	<div fxLayoutAlign="end end" style="padding: 20px">
+		<label style="color: white;" class=" mat-body"><a style="color: white;" href="https://www.ngdesk.com" target="_blank">Powered by
+				ngDesk</a> &#169;</label>
+	</div>
 </div>


### PR DESCRIPTION
#### Reference to issue #100 

Closes #100 

#### Description (Required)

changed the theme of reset password page like login page

##### Test Case 1

1.login to dev1.ngdesk.com with system admin credentials
2.paste the URL in to chrome browser https://dev1.ngdesk.com/reset-password



#### List of General Components affected (Required)

ResetPasswordComponent


**screen-shots**

![Screenshot from 2021-09-14 16-14-50](https://user-images.githubusercontent.com/89504408/133244515-d11bff0d-e2d4-4e92-99f1-76e75c3c453f.png)


