### PR TITLE
Added the validation for One to One relationship field if its already…

### DIFF
--- a/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
+++ b/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
@@ -376,6 +376,21 @@ public class Validator {
 						if (optionalRelatedEntry.isEmpty()) {
 							throw new BadRequestException("BASE_TYPE_RELATIONSHIP_ENTRY_INVALID", vars);
 						}
+
+						if (relationshipType.equals("One to One")) {
+
+							List<Map<String, Object>> allEntries = moduleEntryRepository
+									.findAllEntries(module.getName() + "_" + companyId).get();
+							List<Map<String, Object>> existingEntries = allEntries.stream()
+									.filter(data -> !data.get("_id").equals(entry.get("_id"))
+											&& data.get("DELETED").equals(false) && !data.get(fieldName).equals(null)
+											&& data.get(fieldName).equals(entry.get(fieldName))
+											&& !data.containsKey("EFFECTIVE_TO"))
+									.collect(Collectors.toList());
+							if (!existingEntries.isEmpty()) {
+								throw new BadRequestException("RELATIONSHIP_FIELD_ALREADY_EXIST_IN_OTHER_ENTRY", vars);
+							}
+						}
 					} else if (relationshipType.equals("Many to Many")) {
 						try {
 							List<String> relatedEntryIds = mapper.readValue(

--- a/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
+++ b/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
@@ -378,18 +378,13 @@ public class Validator {
 						}
 
 						if (relationshipType.equals("One to One")) {
-
-							List<Map<String, Object>> allEntries = moduleEntryRepository
-									.findAllEntries(moduleService.getCollectionName(module.getName(), companyId)).get();
-
-							List<Map<String, Object>> existingEntries = allEntries.stream()
-									.filter(data -> !data.get("_id").equals(entry.get("_id"))
-											&& data.get("DELETED").equals(false) && !data.get(fieldName).equals(null)
-											&& data.get(fieldName).equals(entry.get(fieldName))
-											&& !data.containsKey("EFFECTIVE_TO"))
-									.collect(Collectors.toList());
+							Optional<Map<String, Object>> existingEntries = moduleEntryRepository
+									.findEntriesByVariableForRelationship(
+											moduleService.getCollectionName(module.getName(), companyId), fieldName,
+											entry.get(fieldName).toString(), entry.get("_id").toString());
 
 							if (!existingEntries.isEmpty()) {
+
 								throw new BadRequestException("RELATIONSHIP_FIELD_ALREADY_EXIST_IN_OTHER_ENTRY", vars);
 							}
 						}

--- a/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
+++ b/ngDesk-Data-Service/src/main/java/com/ngdesk/data/validator/Validator.java
@@ -380,13 +380,15 @@ public class Validator {
 						if (relationshipType.equals("One to One")) {
 
 							List<Map<String, Object>> allEntries = moduleEntryRepository
-									.findAllEntries(module.getName() + "_" + companyId).get();
+									.findAllEntries(moduleService.getCollectionName(module.getName(), companyId)).get();
+
 							List<Map<String, Object>> existingEntries = allEntries.stream()
 									.filter(data -> !data.get("_id").equals(entry.get("_id"))
 											&& data.get("DELETED").equals(false) && !data.get(fieldName).equals(null)
 											&& data.get(fieldName).equals(entry.get(fieldName))
 											&& !data.containsKey("EFFECTIVE_TO"))
 									.collect(Collectors.toList());
+
 							if (!existingEntries.isEmpty()) {
 								throw new BadRequestException("RELATIONSHIP_FIELD_ALREADY_EXIST_IN_OTHER_ENTRY", vars);
 							}

--- a/ngDesk-Data-Service/src/main/java/com/ngdesk/repositories/module/entry/CustomModuleEntryRepository.java
+++ b/ngDesk-Data-Service/src/main/java/com/ngdesk/repositories/module/entry/CustomModuleEntryRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -107,5 +108,8 @@ public interface CustomModuleEntryRepository {
 	public void updateOCRToMetadata(String dataId, List<String> receipts, String fieldName, String collectionName);
 
 	public Optional<List<Map<String, Object>>> findAllTeams(List<String> teamIds, String userId, String companyId);
+
+	public Optional<Map<String, Object>> findEntriesByVariableForRelationship(String collectionName,
+			String fieldName,String value ,String id);
 
 }

--- a/ngDesk-Data-Service/src/main/java/com/ngdesk/repositories/module/entry/CustomModuleEntryRepositoryImpl.java
+++ b/ngDesk-Data-Service/src/main/java/com/ngdesk/repositories/module/entry/CustomModuleEntryRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.apache.http.util.Asserts;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -1250,6 +1251,15 @@ public class CustomModuleEntryRepositoryImpl implements CustomModuleEntryReposit
 		criteria.andOperator(Criteria.where("DELETED").is(false), Criteria.where("EFFECTIVE_TO").is(null));
 		return mongoOperations.find(new Query(criteria).with(pageable), (Class<Map<String, Object>>) (Class) Map.class,
 				collectionName);
+	}
+
+	@Override
+	public Optional<Map<String, Object>> findEntriesByVariableForRelationship(String collectionName, String fieldName,
+			String value, String id) {
+		Criteria criteria = new Criteria();
+		criteria.andOperator(Criteria.where("DELETED").is(false), Criteria.where("EFFECTIVE_TO").is(null),
+				Criteria.where("_id").ne(id), Criteria.where(fieldName).is(value));
+		return Optional.ofNullable(mongoOperations.findOne(new Query(criteria), Map.class, collectionName));
 	}
 
 	private AggregationOperation lookupForAggregation(String parentCollectionName, String fieldInChild,

--- a/ngDesk-Data-Service/src/main/resources/translations/en.json
+++ b/ngDesk-Data-Service/src/main/resources/translations/en.json
@@ -103,5 +103,6 @@
 	"BASE_VALUE_NOT_NULL": "Base value cannot be null, please try again",
 	"INVALID_DATE_FORMAT": "The date format you have been selected is invalid, please select a valid format",
 	"INVALID_FORM" : "Selected Form doesnot exist or might have been deleted",
-	"FORMULA_NAME_INVALID" :"Formula Name ${1} is invalid or may have been deleted from list formula field, Please try again"
+	"FORMULA_NAME_INVALID" :"Formula Name ${1} is invalid or may have been deleted from list formula field, Please try again",
+	"RELATIONSHIP_FIELD_ALREADY_EXIST_IN_OTHER_ENTRY": "The ${1} may have been used in other existing entry, please try again"
 }

--- a/ngDesk-Data-Service/src/main/resources/translations/en.json
+++ b/ngDesk-Data-Service/src/main/resources/translations/en.json
@@ -102,6 +102,7 @@
 	"TO_CURRENCY_NOT_EMPTY": "To Currency cannot be empty, please try again",
 	"BASE_VALUE_NOT_NULL": "Base value cannot be null, please try again",
 	"INVALID_DATE_FORMAT": "The date format you have been selected is invalid, please select a valid format",
-	"INVALID_FORM" : "Selected Form doesnot exist or might have been deleted"
+	"INVALID_FORM" : "Selected Form doesnot exist or might have been deleted",
+	"RELATIONSHIP_FIELD_ALREADY_EXIST_IN_OTHER_ENTRY": "The ${1} may have been used in other existing entry, please try again"
 
 }


### PR DESCRIPTION
#### Reference to issue (Required)

Closes #183 

#### Checklist (Required)

- [x] code is clean, clear and concise
- [x] coding conventions have been followed
- [x] the issue is updated with time spent

#### Description (Required)

One to one relationship type bug

#### Manual Test Preformed (Required)
List the manual tests that were preformed and the steps to preform them  
**There must be multiple test cases provided, each test case should include the exact and detailed steps to replicate the case**
**I have included 5, test cases here but there will be many time when more cases are required**


##### Test Case 1
**Name: POST NEW COMPANY**

- go to postman.
- given post call URL:[https://dev1.ngdesk.com/api/ngdesk-company-service-v1/company].
- added proper payload for post call for posting new company
- In plugins add "Ticketing", "Expenses"
- perform post
- able to post new company without any errors
- able to login in ngdesk with valid credential

##### Test Case 2
**Name:TEST ONE TO ONE FIELD IN CATEGORIES MODULE**

- go to dev1.ngdesk.com
- login with valid credential
- go to expenses in sidebar
- create two taxes and glcode entries
- go to categories
- create first categories with all required form fields where gl code field is one to one data type
- create first category entry with gl code1 and save it
- able to save without any error
- Create second category entry with same gl code which used in first categories entry, and try to save
- getting error message "The glcode  may have been used in other existing entry, please try again"
- able to validate the one to one data type fields

##### Test Case 3
**Name:TEST ONE TO ONE FIELD IN USER MODULE**

- go to company setting
- go to users
- invite one users
- open the invited users 
- edit contact details of user entry and give the contact which already used in other user entry
- after saving getting errors "The contact  may have been used in other existing entry, please try again"
- able to validate the one to one data type fields

##### Test Case 4
**Name:TESTING IN POSTMAN**
- go to company setting
- go to users
-  open network
- invite one users
- take the payload from network
- go to postman 
- give url for posting new users https://dev1.ngdesk.com/api/ngdesk-data-service-v1/modules/5f68d2d296151b30f85b4f11/data?is_trigger=false
- give proper payload which took from network
- in contact field of users give the contact id which already used for other user
- able to validate and able to throw error
 
##### Test Case 5
**Name:TESTING IN CUSTOM MODULE**

- go to module sidebar
- create one module
- go to fields create one to one realationship field
- in related module select contact
- in contact select full name field
- in custom module select dataid
- give proper display name for fields and save it
- create the edit,list and create layout using that field
- invite few users 
- create entry in custom module by  selecting contact and save it
- create another entry where select contact which we had selected in first entry
- when saving entry able to display error


#### List of General Components affected (Required)

**DATA SERVICE**

#### Types of changes (Required)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


#### Screenshots

- Posting New Company
![image](https://user-images.githubusercontent.com/89505098/133366273-ba873412-3d21-4b5b-a754-9aa48ea9c19f.png)

-Categories module

![image](https://user-images.githubusercontent.com/89505098/133366412-9015a690-b11d-444d-bdc1-9e013adc360d.png)
![image](https://user-images.githubusercontent.com/89505098/133366490-9ba1b415-6ccd-498c-8ff6-f53896c9248c.png)
![Screenshot from 2021-09-15 09-06-59](https://user-images.githubusercontent.com/89505098/133366579-01f0c360-5d25-4528-a093-c45082f2302f.png)
![Screenshot from 2021-09-15 09-06-51](https://user-images.githubusercontent.com/89505098/133366585-96a8d1c1-0ff6-4be7-b7cc-06e7f50a9465.png)
![Screenshot from 2021-09-15 09-08-19](https://user-images.githubusercontent.com/89505098/133366702-4a6faea5-395a-44a6-a58f-2999ea1e4249.png)
![Screenshot from 2021-09-15 09-08-16](https://user-images.githubusercontent.com/89505098/133366706-aef67f78-16cd-4539-97e0-aadd084ea72e.png)
![Screenshot from 2021-09-15 09-07-50](https://user-images.githubusercontent.com/89505098/133366708-a63d4daf-a8a4-4b63-81a8-3beeb6a4e628.png)


-Users module
![image](https://user-images.githubusercontent.com/89505098/133367411-9d98fad5-f401-4bd5-9f84-843268495a8e.png)
![image](https://user-images.githubusercontent.com/89505098/133367541-9d8aeeea-e229-4cf6-b9b6-f42d1ff3bc91.png)
![Screenshot from 2021-09-15 09-19-34](https://user-images.githubusercontent.com/89505098/133367664-8358c399-58c3-4ec8-bfbb-a1088e33631b.png)
![Screenshot from 2021-09-15 09-19-31](https://user-images.githubusercontent.com/89505098/133367668-d595edc7-3862-45ef-aadc-bf1a9a8940df.png)
![Screenshot from 2021-09-15 09-19-24](https://user-images.githubusercontent.com/89505098/133367672-de51916a-05ff-469a-94f9-f3bf10ccd901.png)

- POSTMAN:-

![image](https://user-images.githubusercontent.com/89505098/133368620-67404345-1ea0-47d9-a395-ab72000bdf6c.png)

![image](https://user-images.githubusercontent.com/89505098/133368407-2c777c32-e75f-4994-955d-d751b32d4f10.png)

- CUSTOM MODULE
![Screenshot from 2021-09-15 08-39-27](https://user-images.githubusercontent.com/89505098/133368672-b01653c3-844e-4b4e-a8cd-6fd54fc2d0b9.png)
![Screenshot from 2021-09-15 08-38-29](https://user-images.githubusercontent.com/89505098/133368678-5211cc65-ff1c-45be-b15b-16acd4438289.png)
![Screenshot from 2021-09-15 09-53-20](https://user-images.githubusercontent.com/89505098/133370309-d7fb7384-4a7d-4946-a772-23c8ac477a5e.png)
![Screenshot from 2021-09-15 09-53-13](https://user-images.githubusercontent.com/89505098/133370316-d7dd9ef6-d274-42d5-977d-9f0bb5ecb206.png)
![Screenshot from 2021-09-15 09-53-09](https://user-images.githubusercontent.com/89505098/133370317-e961caea-8254-4259-a9b4-3ea35b7e5930.png)


