### PR TITLE
add CustomNotEmpty for singular and plural field for module

### DIFF
--- a/ngDesk-Module-Service/src/main/java/com/ngdesk/module/dao/Module.java
+++ b/ngDesk-Module-Service/src/main/java/com/ngdesk/module/dao/Module.java
@@ -42,17 +42,18 @@ public class Module {
 	private String parentModule;
 
 	@Schema(description = "Description of the module", required = false, example = "Module to handle books")
-	@CustomNotNull(message = "NOT_NULL", values = { "MODULE_DESCRIPTION" })
 	@Field("DESCRIPTION")
 	@JsonProperty("DESCRIPTION")
 	private String description;
 
 	@Field("SINGULAR_NAME")
 	@JsonProperty("SINGULAR_NAME")
+	@CustomNotEmpty(message = "DAO_VARIABLE_REQUIRED", values = { "SINGULAR_NAME" })
 	private String singular;
 
 	@Field("PLURAL_NAME")
 	@JsonProperty("PLURAL_NAME")
+	@CustomNotEmpty(message = "DAO_VARIABLE_REQUIRED", values = { "PLURAL_NAME" })
 	private String plural;
 
 	@JsonProperty("VALIDATIONS")

--- a/ngDesk-Module-Service/src/main/resources/translations/en.json
+++ b/ngDesk-Module-Service/src/main/resources/translations/en.json
@@ -1,5 +1,7 @@
 {
 	"MODULE_NAME": "Module Name",
+	"SINGULAR_NAME": "Singular Name",
+	"PLURAL_NAME": "Plural Name",
 	"MODULE_DESCRIPTION": "Module Description",
 	"MODULE": "Module",
 	"FIELD_DISPLAY_LABEL": "Field display label",


### PR DESCRIPTION
#### Reference to issue (Required)

Closes #192 

#### Checklist (Required)

- [x] code is clean, clear and concise
- [x] coding conventions have been followed
- [x] the issue is updated with time spent

#### Description (Required)

Module Validation

#### Manual Test Preformed (Required)
List the manual tests that were preformed and the steps to preform them  
**There must be multiple test cases provided, each test case should include the exact and detailed steps to replicate the case**
**I have included 1, test cases here but there will be many time when more cases are required**


##### Test Case 1
**Name:Module Validation**

- go to dev1.ngdesk.com
- login with valid credential
- go to module sideBar
- go to new button and click on it
- give the module name and leave other field
- if try to save getting error ,singular name cant be blank
- if giving only module name and singular name and trying to save,getting error plural name cant be blank 
- give all details while creating new module,able to save it.
- go to module sidesbar
- able to see the plural name of new created module in list of modules





#### List of General Components affected (Required)

**Module Service**

#### Types of changes (Required)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


#### Screenshots
![Screenshot from 2021-09-16 15-30-24](https://user-images.githubusercontent.com/89505098/133592844-cc9e5c87-9efc-46ef-8e88-32b7ce8e5dd5.png)
![Screenshot from 2021-09-16 15-29-59](https://user-images.githubusercontent.com/89505098/133592854-433435db-8cbc-4045-9cf8-6196796a5851.png)
![Screenshot from 2021-09-16 15-29-53](https://user-images.githubusercontent.com/89505098/133592855-a55ae12c-ccd4-47fa-8fc3-86d5ed591c4f.png)
