### PR TITLE
47-enabled after removing from teams

### DIFF
--- a/ngDesk-UI/src/app/render-layout/data-types/relationship.service.ts
+++ b/ngDesk-UI/src/app/render-layout/data-types/relationship.service.ts
@@ -91,11 +91,11 @@ context.fieldsMap['${field.FIELD_ID}']) ;" color="primary">link</mat-icon>
 			<mat-chip-list  [disabled]="!context.editAccess || context.fieldsMap['${field.FIELD_ID}'].NOT_EDITABLE || context.customModulesService.fieldsDisableMap['${field.FIELD_ID}']" #${field.NAME}ChipList
 			[required]="context.fieldsMap['${field.FIELD_ID}'].REQUIRED">
               <mat-chip *ngFor="let entry of context.entry['${field.NAME}']" [selectable]='true'
-                    [removable]=true (removed)="context.remove(entry, '${field.NAME}')" >
+                    [removable]=true (removed)="context.remove(entry, '${field.NAME}', trigautoTipDoc)" >
                     {{entry.PRIMARY_DISPLAY_FIELD}}
                     <mat-icon matChipRemove>cancel</mat-icon>
               </mat-chip>
-              <input #${field.NAME}Input [matAutocomplete]="${field.NAME}_auto"
+              <input #${field.NAME}Input [matAutocomplete]="${field.NAME}_auto" #trigautoTipDoc ="matAutocompleteTrigger"
                     [matChipInputFor]="${field.NAME}ChipList" [matChipInputSeparatorKeyCodes]="context.separatorKeysCodes"
                     [matChipInputAddOnBlur]="true" (matChipInputTokenEnd)="context.customModulesService.resetInput($event)"
                     [formControl]="context.customModulesService.formControls['${fieldControlName}']">

--- a/ngDesk-UI/src/app/render-layout/render-detail-new/render-detail-new.component.ts
+++ b/ngDesk-UI/src/app/render-layout/render-detail-new/render-detail-new.component.ts
@@ -1323,11 +1323,16 @@ export class RenderDetailNewComponent implements OnInit, OnDestroy {
 		}
 	}
 
-	public remove(element, arrayName): void {
+	public remove(element, arrayName, trigger): void {
 		const index = this.entry[arrayName].indexOf(element);
 		if (index >= 0) {
 			const array = this.entry[arrayName];
 			array.splice(index, 1);
+			
+			// to set disabled and enabled content
+			trigger.openPanel();
+			trigger.closePanel();
+
 		}
 	}
 


### PR DESCRIPTION
Closes #47 

Test Case 1

Name: Enabled the chiplist in teams after removing from selected list for creating a new ticket

1. Login to ngdesk.
2. Goto -> Tickets -> New.
3. Create a new ticket.
4. Select some teams from the dropdown to the teams.
5. Observe the selected chip is disabled in the dropdown.
6. Now remove the selected chip and observe the removed chip enabled in the dropdown.
7. Observe no error.
![Screenshot from 2021-10-04 15-39-44](https://user-images.githubusercontent.com/89504233/135838491-13223938-e016-4d27-95bb-f25d07083114.png)
![Screenshot from 2021-10-04 15-40-01](https://user-images.githubusercontent.com/89504233/135838514-f000b080-95ee-4b11-8b43-7166932f523f.png)
