### PR TITLE
Added new API in notification service

### DIFF
--- a/ngDesk-Notification-Service/src/main/java/com/ngdesk/notifications/dao/NotificationAPI.java
+++ b/ngDesk-Notification-Service/src/main/java/com/ngdesk/notifications/dao/NotificationAPI.java
@@ -25,15 +25,12 @@ public class NotificationAPI {
 	NotificationService notificationService;
 
 	@Autowired
-
 	private NotificationRepository notificationRepository;
 
 	@PutMapping("/notification")
-
 	public Notification updateNotification(@Valid @RequestBody Notification notification)
 
 	{
-
 		return notificationService.updateNotification(notification);
 	}
 
@@ -67,5 +64,16 @@ public class NotificationAPI {
 			notification.setRead(true);
 			notificationRepository.save(notification, "notifications");
 		}
+	}
+
+	@PutMapping("/notificationsByModule")
+	public void makeNotificationsRead(@RequestBody Notification notification) {
+		notificationService.checkValidUserId(notification.getRecipientId(), "Users_" + notification.getCompanyId());
+		String moduleName = notificationService.checkValidModuleId(notification.getModuleId(),
+				"modules_" + notification.getCompanyId());
+		notificationService.checkValidDataId(notification.getDataId(),
+				moduleName.replaceAll("\\s+", "_") + "_" + notification.getCompanyId());
+		notificationRepository.markNotificationsRead(notification, "notifications");
+
 	}
 }

--- a/ngDesk-Notification-Service/src/main/java/com/ngdesk/notifications/dao/NotificationService.java
+++ b/ngDesk-Notification-Service/src/main/java/com/ngdesk/notifications/dao/NotificationService.java
@@ -43,7 +43,7 @@ public class NotificationService {
 		Optional<Map<String, Object>> optionalNotification = notificationRepository.findByDataId(dataId,
 				collectionName);
 		if (optionalNotification.isEmpty()) {
-			String vars[] = { "NOTIFICATION" };
+			String vars[] = { "NOT_VALID_DATA_ID" };
 
 			throw new NotFoundException("DAO_NOT_FOUND", vars);
 

--- a/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/CustomNotificationRepository.java
+++ b/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/CustomNotificationRepository.java
@@ -2,6 +2,9 @@ package com.ngdesk.repositories;
 
 import java.util.Map;
 import java.util.Optional;
+
+import javax.validation.Valid;
+
 import com.ngdesk.notifications.dao.Module;
 import com.ngdesk.notifications.dao.Notification;
 
@@ -13,5 +16,7 @@ public interface CustomNotificationRepository {
 
 	public void markAllNotificationsAsRead(String companyId, String userId, String collectionName);
 
-	public Optional<Notification>  findByIdandRequestorId(String notificationId, String requestorId, String string);
+	public Optional<Notification> findByIdandRequestorId(String notificationId, String requestorId, String string);
+
+	public void markNotificationsRead(Notification notification, String collectionName);
 }

--- a/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/CustomNotificationRepositoryImpl.java
+++ b/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/CustomNotificationRepositoryImpl.java
@@ -3,6 +3,9 @@ package com.ngdesk.repositories;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -49,6 +52,20 @@ public class CustomNotificationRepositoryImpl implements CustomNotificationRepos
 		criteria.andOperator(Criteria.where("_id").is(notificationId), Criteria.where("recipientId").is(requestorId));
 		Query query = new Query(criteria);
 		return Optional.ofNullable(mongoOperations.findOne(query, Notification.class, collectionName));
+	}
+
+	@Override
+	public void markNotificationsRead(Notification notification, String collectionName) {
+		Criteria criteria = new Criteria();
+		criteria.andOperator(Criteria.where("companyId").is(notification.getCompanyId()),
+				Criteria.where("recipientId").is(notification.getRecipientId()),
+				Criteria.where("dataId").is(notification.getDataId()),
+				Criteria.where("moduleId").is(notification.getModuleId()));
+		Query query = new Query(criteria);
+		Update update = new Update();
+		update.set("read", true);
+		update.set("dateUpdated", new Date());
+		mongoOperations.updateMulti(query, update, collectionName);
 	}
 
 }

--- a/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/NotificationRepository.java
+++ b/ngDesk-Notification-Service/src/main/java/com/ngdesk/repositories/NotificationRepository.java
@@ -1,11 +1,13 @@
 package com.ngdesk.repositories;
 
 import org.springframework.stereotype.Repository;
+
 import com.ngdesk.notifications.dao.Notification;
-import com.ngdesk.repositories.CustomNgdeskRepository;
 
 @Repository
 public interface NotificationRepository
 		extends CustomNotificationRepository, CustomNgdeskRepository<Notification, String> {
+
+	
 
 }


### PR DESCRIPTION
Closes #297 

#### projects Affected(need to start in Local)
- Notification-service

Test Secnarios
1) make use of below payload and url in postman(change the data accordingly)

- URL: https://dev1.ngdesk.com/api/ngdesk-notification-service-v1/notificationsByModule

- PAYLOAD:

{
    "companyId":"619361609fab7f3df80246c9",
  "moduleId": "5f68d2d296151b30f85b4f12",
  "dataId": "619361619fab7f3df80246ec",
  "recipientId": "619361619fab7f3df80246e7"
}
2) pass the moduleId , dataId and recipientId of notification which you want to make read as true
3) make the put call
4)you can observe in database that the notifications field "read" with respect to given moduleId, dataId and recepirntId will turn to true.
#### ScreenShots
![Screenshot from 2021-11-19 14-17-20](https://user-images.githubusercontent.com/89504216/142593318-656c6d9f-caf1-4108-a627-3a91145d3a59.png)
![Screenshot from 2021-11-19 14-17-46](https://user-images.githubusercontent.com/89504216/142593329-ddce27a2-f392-4f77-b2c9-1f15132f163e.png)
![Screenshot from 2021-11-19 14-17-57](https://user-images.githubusercontent.com/89504216/142593338-ae9c24a8-7584-4985-b713-dc42cbd641c7.png)
